### PR TITLE
Allow entry points as array of strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-esm-plugin",
-  "version": "0.2.9",
+  "version": "0.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 const deepcopy = require('deepcopy');
 const SingleEntryPlugin = require('webpack/lib/SingleEntryPlugin');
+const MultiEntryPlugin = require('webpack/lib/MultiEntryPlugin');
 const JsonpTemplatePlugin = require('webpack/lib/web/JsonpTemplatePlugin');
 const SplitChunksPlugin = require('webpack/lib/optimize/SplitChunksPlugin');
 const chalk = require('chalk');
@@ -53,7 +54,12 @@ class BabelEsmPlugin {
       }
 
       Object.keys(compiler.options.entry).forEach(entry => {
-        childCompiler.apply(new SingleEntryPlugin(compiler.context, compiler.options.entry[entry], entry));
+        const entryFiles = compiler.options.entry[entry]
+        if (Array.isArray(entryFiles)) {
+          childCompiler.apply(new MultiEntryPlugin(compiler.context, entryFiles, entry));
+        } else {
+          childCompiler.apply(new SingleEntryPlugin(compiler.context, entryFiles, entry));
+        }
       });
 
       // Convert entry chunk to entry file

--- a/tests/multiple-entry-files/fixtures/first.js
+++ b/tests/multiple-entry-files/fixtures/first.js
@@ -1,0 +1,2 @@
+let config = {a:10, b:20};
+const {a} = config;

--- a/tests/multiple-entry-files/fixtures/output.es6.js
+++ b/tests/multiple-entry-files/fixtures/output.es6.js
@@ -1,0 +1,113 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(1);
+module.exports = __webpack_require__(2);
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports) {
+
+let config = {
+  a: 10,
+  b: 20
+};
+const a = config.a;
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports) {
+
+const init = [1, 2, 3, 4];
+const final = [...init, 5];
+
+/***/ })
+/******/ ]);

--- a/tests/multiple-entry-files/fixtures/output.js
+++ b/tests/multiple-entry-files/fixtures/output.js
@@ -1,0 +1,113 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(1);
+module.exports = __webpack_require__(2);
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports) {
+
+var config = {
+  a: 10,
+  b: 20
+};
+var a = config.a;
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports) {
+
+var init = [1, 2, 3, 4];
+var final = [].concat(init, [5]);
+
+/***/ })
+/******/ ]);

--- a/tests/multiple-entry-files/fixtures/second.js
+++ b/tests/multiple-entry-files/fixtures/second.js
@@ -1,0 +1,2 @@
+const init = [1,2,3,4]
+const final = [...init, 5];

--- a/tests/multiple-entry-files/multiple-entry-files.test.js
+++ b/tests/multiple-entry-files/multiple-entry-files.test.js
@@ -1,0 +1,40 @@
+import test from 'ava';
+import { getCompiler, defaultConfig, runWebpack } from '../webpack-utils';
+import * as fs from 'fs';
+import {promisify} from 'util';
+
+const readFile = promisify(fs.readFile);
+
+test('multiple-entries is being tested', t => {
+  t.pass();
+})
+test('esm files are being generated', async t => {
+  const config = Object.assign({}, defaultConfig, {
+    entry : {
+      index: [
+        './tests/multiple-entry-files/fixtures/first.js', 
+        './tests/multiple-entry-files/fixtures/second.js'
+      ]
+    },
+    output: {
+      path: `${__dirname}/output`,
+      filename: 'index.js',
+    }
+  });
+  const compiler = getCompiler(config);
+  await runWebpack(compiler);
+  const es5FixtureFileContents = await readFile(`${__dirname}/fixtures/output.js`, {
+    encoding: 'utf-8',
+  });
+  const es5GeneratedFileContents = await readFile(`${__dirname}/output/index.js`, {
+    encoding: 'utf-8',
+  });
+  const esmFixtureFileContents = await readFile(`${__dirname}/fixtures/output.es6.js`, {
+    encoding: 'utf-8',
+  });
+  const esmGeneratedFileContents = await readFile(`${__dirname}/output/index.es6.js`, {
+    encoding: 'utf-8',
+  });
+  t.is(es5FixtureFileContents, es5GeneratedFileContents);
+  t.is(esmFixtureFileContents, esmGeneratedFileContents);
+});


### PR DESCRIPTION
The plugin fails when an entry point is an array of strings instead of a string:

```js
entry: {
  // this fails
  main: ['./shared/js/polyfill.legacy.js', './main.js'],
},
```

This PR fixes the problem by using `MultiEntryPlugin` when the entry point value is an array.