### PR TITLE
Updating the new files in parent chunks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,17 +122,42 @@ class BabelEsmPlugin {
             );
 
           childCompiler.runAsChild((err, entries, childCompilation) => {
-            if (!err) {
-              compilation.assets = Object.assign(
-                childCompilation.assets,
-                compilation.assets,
-              );
-              compilation.namedChunkGroups = Object.assign(
-                childCompilation.namedChunkGroups,
-                compilation.namedChunkGroups,
-              );
+            if (err) {
+              return childProcessDone(err);
             }
-            err && compilation.errors.push(err);
+
+            if (childCompilation.errors.length > 0) {
+              return childProcessDone(childCompilation.errors[0]);
+            }
+
+            compilation.assets = Object.assign(
+              childCompilation.assets,
+              compilation.assets,
+            );
+
+            compilation.namedChunkGroups = Object.assign(
+              childCompilation.namedChunkGroups,
+              compilation.namedChunkGroups,
+            );
+
+            const childChunkFileMap = childCompilation.chunks.reduce(
+              (chunkMap, chunk) => {
+                chunkMap[chunk.name] = chunk.files;
+                return chunkMap;
+              },
+              {},
+            );
+
+            compilation.chunks.forEach(chunk => {
+              const childChunkFiles = childChunkFileMap[chunk.name];
+
+              if (childChunkFiles) {
+                chunk.files.push(
+                  ...childChunkFiles.filter(v => !chunk.files.includes(v)),
+                );
+              }
+            });
+
             childProcessDone();
           });
         },


### PR DESCRIPTION
Many plugins use the `chunk.files` array to work on a chunk. This updates the parent chunk with the right set of modern files

Adding additional error handling for silent errors from `compilation.errors` 