### PR TITLE
Hotfix loader object reference check

### DIFF
--- a/src/babel-utils.js
+++ b/src/babel-utils.js
@@ -60,7 +60,7 @@ const getBabelLoader = config => {
         (rule.use &&
           rule.use.loader &&
           rule.use.loader.includes(BABEL_LOADER_NAME)) ||
-        rule.loader.includes(BABEL_LOADER_NAME)
+        rule.loader && rule.loader.includes(BABEL_LOADER_NAME)
       ) {
         babelConfig = rule.use || rule;
       }


### PR DESCRIPTION
When a loader does not match the first set of conditions, the presence
of the loader object must be still checked.

This commit fixes #28