### PR TITLE
Hotfix babel present option reference check

### DIFF
--- a/src/babel-utils.js
+++ b/src/babel-utils.js
@@ -12,7 +12,8 @@ const makeESMPresetOptions = options => {
   options.presets = options.presets || [];
   options.presets.forEach(preset => {
     if (!Array.isArray(preset)) return;
-    const [name, options] = preset;
+    let [name, options] = preset;
+    options = options || {};
     if (
       name.includes('@babel/preset-env') ||
       name.includes('@babel\\preset-env')


### PR DESCRIPTION
Resolve undefined babel present option object, as a fallback to an empty object.

This commit fixes #30