### PR TITLE
allow newer versions of webpack as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "deepcopy": "1.0.0"
   },
   "peerDependencies": {
-    "webpack": "4.28.4"
+    "webpack": "^4.28.4"
   },
   "devDependencies": {
     "@babel/core": "7.9.0",

--- a/src/babel-utils.js
+++ b/src/babel-utils.js
@@ -34,7 +34,10 @@ const makeESMPresetOptions = options => {
     );
     options.presets.push([
       '@babel/preset-env',
-      { targets: { esmodules: true } },
+      {
+        targets: { esmodules: true },
+        bugfixes: true,
+      },
     ]);
   }
   return options;


### PR DESCRIPTION
@prateekbh this will allow webpack version within 4.x range

I would recommend you do this by default for all your dependencies as it wil be easier to upgrade for bugfixes and other non breaking changes.