### PR TITLE
Fixed loading babel-loader options in create-react-app apps

### DIFF
--- a/src/babel-utils.js
+++ b/src/babel-utils.js
@@ -72,6 +72,12 @@ const getBabelLoader = config => {
         (rule.loader && rule.loader.includes(BABEL_LOADER_NAME))
       ) {
         babelConfig = rule.use || rule;
+      } else if (rule.oneOf && Array.isArray(rule.oneOf)) {
+        rule.oneOf.forEach((rule) => {
+          if (rule.loader && rule.loader.includes(BABEL_LOADER_NAME)) {
+            babelConfig = rule;
+          }
+        });
       }
     }
   });


### PR DESCRIPTION
Hi there,

In the `create-react-app` projects, `babel-loader` options is placed in the `oneOf` object that I added to the code.

Cheers.